### PR TITLE
:bug: Allow messages to be passed as args

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ exception constructor.
 
     exceptions.not_found('Nothing to see here')  # returns a 404 with custom error message
 
+    exceptions.not_found(message='Nothing to see here')  # also returns a 404 with custom error message, using the `message` kwarg
+
     exceptions.conflict('Race condition!', payload={'error': '4-8-15-16-23-42'})  # custom error & payload
 
 Currently supported HTTP errors include 400 - bad_request(), 401 - unauthorized(), 403 -

--- a/flask_exceptions/extension.py
+++ b/flask_exceptions/extension.py
@@ -15,7 +15,7 @@ def exception(message):
         def wrapper(self, *args, **kwargs):
             """Innermost decorator wrapper - this is confusing."""
             if self.messages:
-                kwargs['message'] = args[0] if args else message
+                kwargs['message'] = args[0] if args else kwargs.get('message', message)
             else:
                 kwargs['message'] = None
             kwargs['prefix'] = self.prefix
@@ -125,41 +125,41 @@ class AddExceptions(object):
     # Exception class wrappers sorted by error code
 
     @exception('Invalid request parameters')
-    def bad_request(self, **kwargs):
+    def bad_request(self, *_, **kwargs):
         """Return an Exception to use when you want to return a 400."""
         return BadRequest(**kwargs)
 
     @exception('Unauthorized')
-    def unauthorized(self, **kwargs):
+    def unauthorized(self, *_, **kwargs):
         """Return an Exception to use when you want to return a 401."""
         return Unauthorized(**kwargs)
 
     @exception('Forbidden')
-    def forbidden(self, **kwargs):
+    def forbidden(self, *_, **kwargs):
         """Return an Exception to use when you want to return a 403."""
         return Forbidden(**kwargs)
 
     @exception('Resource not found')
-    def not_found(self, **kwargs):
+    def not_found(self, *_, **kwargs):
         """Return an Exception to use when you want to return a 404."""
         return NotFound(**kwargs)
 
     @exception('Conflict')
-    def conflict(self, **kwargs):
+    def conflict(self, *_, **kwargs):
         """Return an Exception to use when you want to return a 409."""
         return Conflict(**kwargs)
 
     @exception('Gone')
-    def gone(self, **kwargs):
+    def gone(self, *_, **kwargs):
         """Return an Exception to use when you want to return a 410."""
         return Gone(**kwargs)
 
     @exception('Unsupported Media')
-    def unsupported_media(self, **kwargs):
+    def unsupported_media(self, *_, **kwargs):
         """Return an Exception to use when you want to return a 415."""
         return UnsupportedMedia(**kwargs)
 
     @exception('Unprocessable Entity')
-    def unprocessable_entity(self, **kwargs):
+    def unprocessable_entity(self, *_, **kwargs):
         """Return an Exception to use when you want to return a 422."""
         return UnprocessableEntity(**kwargs)

--- a/flask_exceptions/tests/test_extension.py
+++ b/flask_exceptions/tests/test_extension.py
@@ -108,10 +108,20 @@ class TestExceptions(unittest.TestCase):
         self.app.statsd.incr.assert_called_once_with(extension.DEFAULT_PREFIX + '.400')
 
     @mock_statsd
-    def test_bad_request_custom_msg(self):
-        """Test BadRequest/400 exception with a custom error message."""
+    def test_bad_request_custom_msg_arg(self):
+        """Test BadRequest/400 exception with a custom error message passed as an arg."""
         exceptions = AddExceptions(self.app)
         bad_request = exceptions.bad_request('Oh noes!')
+
+        self.assertIsInstance(bad_request, extension.BadRequest)
+        self.assertDictEqual(bad_request.to_dict(), {'message': 'Oh noes!'})
+        self.app.statsd.incr.assert_called_once_with(extension.DEFAULT_PREFIX + '.400')
+
+    @mock_statsd
+    def test_bad_request_custom_msg(self):
+        """Test BadRequest/400 exception with a custom error message passed as a kwarg."""
+        exceptions = AddExceptions(self.app)
+        bad_request = exceptions.bad_request(message='Oh noes!')
 
         self.assertIsInstance(bad_request, extension.BadRequest)
         self.assertDictEqual(bad_request.to_dict(), {'message': 'Oh noes!'})

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@ from setuptools import setup
 
 setup(
     name='Flask-Exceptions',
-    version='1.1.0',
+    version='1.1.1',
     url='https://github.com/bbelyeu/flask-exceptions',
-    download_url='https://github.com/bbelyeu/flask-exceptions/archive/1.1.0.zip',
+    download_url='https://github.com/bbelyeu/flask-exceptions/archive/1.1.1.zip',
     license='MIT',
     author='Brad Belyeu',
     author_email='bradleylamar@gmail.com',


### PR DESCRIPTION
Problem:
========

Currently, the exceptions accept only `**kwargs`, which are used when
constructing the exception object. `message` strings are therefore able
to be passed as a `kwarg`, but not as an argument. Originally, a pylint
error was being raised in the test file and was actually ignored.

Solution:
=========

- Updated the documentation to allow for either case
- Updated the helper functions to take message as an argument