### PR TITLE
Small tweak to incorrect readme instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ celerybeat-schedule
 
 # dotenv
 .env
+.envrc
 
 # virtualenv
 .venv

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Flask-StatsDClient(https://pypi.python.org/pypi/Flask-StatsDClient/1.0.1) simply
 
     app = Flask(__name__)
     statsd = StatsDClient(app)
-    exceptions = AddExceptions(app, statsd)
+    exceptions = AddExceptions(app, statsd=statsd)
 
 The default StatsD counter will be in the form `exceptions.xxx` with xxx being the status code.
 This does not take into account any prefix you added when instantiating StatsClient itself.


### PR DESCRIPTION
The README says that you can pass a statsd client in the following manner:
`exceptions = AddExceptions(app, statsd)`.
However, the second positional argument to `__init__` for the `AddExceptions` class is a config object to use (the third is the statsd counter). For obvious reasons, it fails to instantiate the object when a statsd client is passed in as a config object :)
This change merely updates the README to correctly reflect how to initialize the `AddExceptions` object.

Also, I added .envrc to the .gitignore to correctly ignore both so it can be up to the contributor whether to use autoenv or direnv.